### PR TITLE
Add health check API blueprint

### DIFF
--- a/opentakserver/blueprints/ots_api/__init__.py
+++ b/opentakserver/blueprints/ots_api/__init__.py
@@ -15,6 +15,7 @@ from opentakserver.blueprints.ots_api.mission_api import data_sync_api
 from opentakserver.blueprints.ots_api.group_api import group_api
 from opentakserver.blueprints.ots_api.eud_stats_api import eud_stats_blueprint
 from opentakserver.blueprints.ots_api.plugin_api import plugin_blueprint
+from opentakserver.blueprints.ots_api.health_api import health_api
 
 ots_api = Blueprint("ots_api", __name__)
 ots_api.register_blueprint(api_blueprint)
@@ -33,3 +34,4 @@ ots_api.register_blueprint(group_api)
 ots_api.register_blueprint(eud_stats_blueprint)
 ots_api.register_blueprint(plugin_blueprint)
 ots_api.register_blueprint(token_api_blueprint)
+ots_api.register_blueprint(health_api)

--- a/opentakserver/blueprints/ots_api/health_api.py
+++ b/opentakserver/blueprints/ots_api/health_api.py
@@ -1,0 +1,26 @@
+from flask import Blueprint, jsonify
+from flask_security import auth_required
+
+# Blueprint for health endpoints
+health_api = Blueprint("health_api", __name__)
+
+
+@health_api.route("/api/health/ots")
+@auth_required()
+def health_ots():
+    """Placeholder health check for OTS."""
+    return jsonify({"status": "ok"})
+
+
+@health_api.route("/api/health/cot")
+@auth_required()
+def health_cot():
+    """Placeholder health check for CoT."""
+    return jsonify({"status": "ok"})
+
+
+@health_api.route("/api/health/eud")
+@auth_required()
+def health_eud():
+    """Placeholder health check for EUD."""
+    return jsonify({"status": "ok"})

--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -1,0 +1,10 @@
+def test_health_endpoints(auth):
+    for endpoint in ("ots", "cot", "eud"):
+        response = auth.get(f"/api/health/{endpoint}")
+        assert response.status_code == 200
+
+
+def test_health_requires_auth(client):
+    for endpoint in ("ots", "cot", "eud"):
+        response = client.get(f"/api/health/{endpoint}")
+        assert response.status_code in (401, 302)


### PR DESCRIPTION
## Summary
- add `health_api` blueprint with OTS, CoT and EUD health endpoints
- register `health_api` within OTS API blueprint
- test authenticated access for new endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_b_68b066acfbec832bbc417e7a804b4f67