### PR TITLE
Tail cot_parser entries from OTS log

### DIFF
--- a/opentakserver/blueprints/ots_api/health_api.py
+++ b/opentakserver/blueprints/ots_api/health_api.py
@@ -6,7 +6,7 @@ from opentakserver.health.cot_parser import (
     find_errors,
     query_systemd,
     rabbitmq_check,
-    tail_log,
+    tail_ots_log_for_cot_parser_entries,
     current_timestamp,
 )
 
@@ -26,7 +26,7 @@ def health_ots():
 def health_cot():
     """Health check for the CoT parser service."""
     service_state = query_systemd()
-    log_lines = tail_log()
+    log_lines = tail_ots_log_for_cot_parser_entries()
     log_errors = find_errors(log_lines)
     rabbit_ok = rabbitmq_check()
 

--- a/tests/test_health_api.py
+++ b/tests/test_health_api.py
@@ -9,7 +9,10 @@ def test_health_endpoints(auth):
 
 def test_health_cot_healthy(auth):
     with patch("opentakserver.health.cot_parser.query_systemd", return_value="active"), \
-        patch("opentakserver.health.cot_parser.tail_log", return_value=["all good"]), \
+        patch(
+            "opentakserver.health.cot_parser.tail_ots_log_for_cot_parser_entries",
+            return_value=["all good"],
+        ), \
         patch("opentakserver.health.cot_parser.find_errors", return_value=[]), \
         patch("opentakserver.health.cot_parser.rabbitmq_check", return_value=True):
         response = auth.get("/api/health/cot")
@@ -22,7 +25,10 @@ def test_health_cot_healthy(auth):
 
 def test_health_cot_unhealthy_strict(auth):
     with patch("opentakserver.health.cot_parser.query_systemd", return_value="inactive"), \
-        patch("opentakserver.health.cot_parser.tail_log", return_value=["error"]), \
+        patch(
+            "opentakserver.health.cot_parser.tail_ots_log_for_cot_parser_entries",
+            return_value=["error"],
+        ), \
         patch("opentakserver.health.cot_parser.find_errors", return_value=["error"]), \
         patch("opentakserver.health.cot_parser.rabbitmq_check", return_value=False):
         response = auth.get("/api/health/cot?strict=true")


### PR DESCRIPTION
## Summary
- rename health check helper `tail_log` to `tail_ots_log_for_cot_parser_entries`
- read from `opentakserver.log` and filter for `cot_parser` tagged entries
- adjust health API and tests to use new tailing helper

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_b_68b07faacc20832b80db90a2c3dc797c